### PR TITLE
lots of things - but most important be able to use any suitetalk version and applicationid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![devDependencies Status](https://david-dm.org/cancerberosgx/netsuite-uploader-util/status.svg)](https://david-dm.org/cancerberosgx/netsuite-uploader-util)
+
 # netsuite-uploader-util
 
 Helper library for uploading files from your local computer into the NetSuite File Cabinet from nodejs.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,46 @@
 # netsuite-uploader-util
+
 Helper library for uploading files from your local computer into the NetSuite File Cabinet from nodejs.
+
+# Install
+
+```
+ $ npm install netsuite-uploader-util 
+```
+
+# Usage
+
+Simple using SuiteTalk 2015_1 so you dont need application ID: 
+
+```javascript
+// Constants: - change according to your needs
+var account = 'TSTDRV1234567';
+var role = 3;
+var localfile = '/home/me/script1.js' // the local file to upload
+var remoteFile = 'SuiteScripts/script1.js' // the path to file cabinet path to update or create. You can pass non-existing folders - in that case they will be created recursively, like mkdir -p
+
+var nsutil = require('netsuite-uploader-util');
+
+var client = new nsutil.SuiteTalk();
+var creds = nsutil.Credentials;
+client.init(creds.email, creds.password, account, role).then(() => {
+    client.upload(file.path, suiteScriptPath).then(r=>{
+            console.log('  Uploaded File: ' + suiteScriptPath);
+        }, err => {
+            console.log('  Failed to Upload File: ' + err);
+        });
+    });
+});
+
+```
+
+Or you can use latest SuiteTalk versions, currently 2017_2. For this you need an application ID which you can create in Setup->Integration->Manage Integrations menu. Is the same as before but we pass extra two parameters to client.init(). `nsVersion` parameter is optional. Example: 
+
+```javascript
+var applicationId = 'E296719E-C000-4719-B60A-89B72FB65E88';
+var nsVersion = '2017_2';
+client.init(creds.email, creds.password, account, role, applicationId, nsVersion)....
+```
 
 # Sample gulpfile.js task that leverages this utility:
 

--- a/lib/suitetalk.js
+++ b/lib/suitetalk.js
@@ -1,238 +1,242 @@
 module.exports = (function () {
-
-	var Q = require('q'),
-		https = require('https'),
-		restlet = require('./restlet'),
-		path = require('path'),
-		format = require('string-template'),
-		fs = require('fs');
-
-	var folder_cache = {};
-
-	return SuiteTalk;
-
-	function SuiteTalk() {
-		var self = this;
-
-		// Properties
-		self.email = '';
-		self.password = '';
-		self.account = '';
-		self.role = '';
-		self.hostname = '';
-
-		// Behaviors
-		self.init = init;
-		self.upload = upload;
-
-		// Public Implementations:
-		function init(email, password, account, role) {
-			if (!email)
-				throw 'email is required';
-			if (!password)
-				throw 'password is required';
-			if (!account)
-				throw 'account is required';
-			if (!role)
-				throw 'role is required';
-			self.email = email;
-			self.password = password;
-			self.account = account;
-			self.role = role;
-
-			var deferred = Q.defer();
-
-			if (self.hostname) {
-				deferred.resolve();
-			} else {
-				restlet.getDataCenter(email, password, account, role).then(function (dataCenter) {
-					self.hostname = path.basename(dataCenter.dataCenterURLs.webservicesDomain);
-					deferred.resolve();
-				});
-			}
-
-			return deferred.promise;
-		}
-
-		function upload(target, dest) {
-			if (!self.hostname)
-				throw 'Must call init first';
-
-			return getParentFolderId(dest).then(function (parent) {
-				var name = dest.split('/').pop();
-				return uploadFile(parent, name, target);
-			});
-
-			function getParentFolderId(dest) {
-				var deferred = Q.defer();
-
-				var dest_parts = dest.split('/').filter(function (p) { return p });
-				function step(parent) {
-					if (dest_parts.length == 1) {
-						deferred.resolve(parent);
-					} else {
-						getFolderId(parent, dest_parts.shift()).then(step);
-					}
+	
+		var Q = require('q'),
+			https = require('https'),
+			restlet = require('./restlet'),
+			path = require('path'),
+			format = require('string-template'),
+			fs = require('fs');
+	
+		var folder_cache = {};
+	
+	
+		function SuiteTalk() {
+			let self = this;
+	
+			self.nsVersionLatestKnown = '2017_2'
+	
+			// Properties
+			self.email = '';
+			self.password = '';
+			self.account = '';
+			self.role = '';
+			self.hostname = '';
+	
+	
+			// Behaviors
+			self.init = init;
+			self.upload = upload;
+	
+			// Public Implementations:
+			/**
+			 * @param {String} email 
+			 * @param {String} password 
+			 * @param {String} account 
+			 * @param {String} role 
+			 * @param {String} applicationId 
+			 * @param {String} nsVersion something like '2017_2'. If you use 2015_2 or later you could also need to indicate an application id. If ommited and no applicationId is passed 2015_1 is used, otherwhise the latest known that currently is 2017_2
+			 */
+			function init(email, password, account, role, applicationId, nsVersion) {
+				if (!email)
+					throw 'email is required';
+				if (!password)
+					throw 'password is required';
+				if (!account)
+					throw 'account is required';
+				if (!role)
+					throw 'role is required';
+				self.email = email;
+				self.password = password;
+				self.account = account;
+				self.role = role;
+	
+				if (self.applicationId && !nsVersion) {
+					nsVersion = self.nsVersionLatestKnown
 				}
-				step();
-
+				self.nsVersion = nsVersion || '2015_1';
+	
+				let nsVersionLaterThan2015_2 = parseInt(self.nsVersion.replace('_', '.'), 10) > 2015.19;
+	
+				self.applicationId = applicationId;
+				if (nsVersionLaterThan2015_2 && !self.applicationId) {
+					self.log('WARNING - using suitetalk greater than 2015_2 requires that you also provide an applicationId which you didn\'t');
+				}
+	
+				self.globalApplicationIdFragment = self.applicationId ? `<applicationInfo xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><applicationId xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">${applicationId}</applicationId></applicationInfo>` : ``;
+	
+				var deferred = Q.defer();
+	
+				if (self.hostname) {
+					deferred.resolve();
+				} else {
+					restlet.getDataCenter(email, password, account, role).then(function (dataCenter) {
+						self.hostname = path.basename(dataCenter.dataCenterURLs.webservicesDomain);
+						deferred.resolve();
+					}).catch((ex) => { self.log('getDataCenter', ex) });
+				}
+	
 				return deferred.promise;
 			}
-		}
-
-		// Private Implementations:
-
-		function formatXML(xmltemplate, fields) {
-			var params = {
-				email: self.email,
-				password: self.password,
-				account: self.account,
-				role: self.role
-			};
-			for (var i in fields) {
-				params[i] = fields[i];
-			}
-			return format(xmltemplate, params);
-		}
-
-		function POST(body, soapAction) {
-			var deferred = Q.defer();
-
-			var options = {
-				hostname: self.hostname,
-				port: 443,
-				path: '/services/NetSuitePort_2014_2',
-				method: 'POST',
-				headers: {
-					'Content-Type': 'text/xml; charset=utf-8'
-				}
-			};
-
-			if (soapAction) {
-				options.headers['SOAPAction'] = soapAction;
-			}
-
-			var req = https.request(options, function (res) {
-				var res_body = '';
-				res.on('data', function (chunk) { res_body += chunk; });
-				res.on('end', function () {
-					// console.log('RECEIVED: \r\n' + res_body);
-					var matches = /isSuccess="(.*?)"/.exec(res_body);
-					if (matches) {
-						var result = matches[1];
-						if (result == "false") {
-							var err = /<platformCore:message>([\s|\S]*?)<\/platformCore:message>/.exec(res_body)[1];
-							deferred.reject(err);
+	
+			function upload(target, dest) {
+				if (!self.hostname)
+					throw 'Must call init first';
+	
+				return getParentFolderId(dest).then(function (parent) {
+					var name = dest.split('/').pop();
+					return uploadFile(parent, name, target);
+				}).catch((ex) => { self.log('getParentFolderId', ex) });
+	
+				function getParentFolderId(dest) {
+					var deferred = Q.defer();
+	
+					var dest_parts = dest.split('/').filter(function (p) { return p });
+					function step(parent) {
+						if (dest_parts.length == 1) {
+							deferred.resolve(parent);
 						} else {
-							deferred.resolve(res_body);
-						}
-					} else {
-						matches = /<platformFaults:message>([\s|\S]*?)<\/platformFaults:message>/.exec(res_body);
-						if (matches) {
-							deferred.reject(matches[1]);
-						} else {
-							deferred.reject('Unknown Error: ' + res_body);
+							getFolderId(parent, dest_parts.shift()).then(step).catch((ex) => { self.log('getFolderId', ex) });
 						}
 					}
+					step();
+	
+					return deferred.promise;
+				}
+			}
+	
+			// Private Implementations:
+	
+			function formatXML(xmltemplate, fields) {
+				var params = {
+					email: self.email,
+					password: self.password,
+					account: self.account,
+					role: self.role
+				};
+				for (var i in fields) {
+					params[i] = fields[i];
+				}
+				return format(xmltemplate, params);
+			}
+	
+			function POST(body, soapAction) {
+				var deferred = Q.defer();
+	
+				var options = {
+					hostname: self.hostname,
+					port: 443,
+					path: `/services/NetSuitePort_${self.nsVersion}`,
+					method: 'POST',
+					headers: {
+						'Content-Type': 'text/xml; charset=utf-8'
+					}
+				};
+	
+				if (soapAction) {
+					options.headers['SOAPAction'] = soapAction;
+				}
+	
+				var req = https.request(options, function (res) {
+					var res_body = '';
+					res.on('data', function (chunk) { res_body += chunk; });
+					res.on('end', function () {
+						// self.log('RECEIVED: \r\n' + res_body);
+						var matches = /isSuccess="(.*?)"/.exec(res_body);
+						if (matches) {
+							var result = matches[1];
+							if (result == "false") {
+								var err = /<platformCore:message>([\s|\S]*?)<\/platformCore:message>/.exec(res_body)[1];
+								deferred.reject(err);
+							} else {
+								deferred.resolve(res_body);
+							}
+						} else {
+							matches = /<platformFaults:message>([\s|\S]*?)<\/platformFaults:message>/.exec(res_body);
+							if (matches) {
+								deferred.reject(matches[1]);
+							} else {
+								deferred.reject('Unknown Error: ' + res_body);
+							}
+						}
+					});
+					res.on('error', function (e) {
+						//self.log('FAILED: ' + e);
+						deferred.reject(e);
+					});
 				});
-				res.on('error', function (e) {
-					//console.log('FAILED: ' + e);
-					deferred.reject(e);
-				});
-			});
-			//console.log('SENDING: \r\n' + body);
-			req.write(body);
-			req.end();
-			return deferred.promise;
-		}
-
-		function uploadFile(parent, name, target) {
-			parent = parent || '@NONE@';
-
-			return getFileId(parent, name).then(function (fileid) {
-				var xmlAdd = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><add xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:File" internalId=""><q1:name>{filename}</q1:name><q1:content>{content}</q1:content><q1:folder internalId="{parent}" type="folder" /></record></add></soap:Body></soap:Envelope>';
-				var xmlUpdate = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><update xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:File" internalId="{fileid}"><q1:content>{content}</q1:content></record></update></soap:Body></soap:Envelope>';
-				return readFileContents(target).then(function (content) {
-					var xml = formatXML(fileid ? xmlUpdate : xmlAdd,
+				//self.log('SENDING: \r\n' + body);
+				req.write(body);
+				req.end();
+				return deferred.promise;
+			}
+	
+			function uploadFile(parent, name, target) {
+				parent = parent || '@NONE@';
+	
+				return getFileId(parent, name).then(function (fileid) {
+					var xmlAdd = `<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><add xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:File" internalId=""><q1:name>{filename}</q1:name><q1:content>{content}</q1:content><q1:folder internalId="{parent}" type="folder" /></record></add></soap:Body></soap:Envelope>`;
+					var xmlUpdate = `<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><update xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:File" internalId="{fileid}"><q1:content>{content}</q1:content></record></update></soap:Body></soap:Envelope>`;
+					return readFileContents(target).then(function (content) {
+						var xml = formatXML(fileid ? xmlUpdate : xmlAdd,
+							{
+								filename: name,
+								fileid: fileid,
+								parent: parent,
+								content: content
+							});
+						return POST(xml, fileid ? 'update' : 'add').then(function () {
+							var verb = fileid ? 'Updated ' : 'Added ';
+							self.log(verb + 'file: ' + name);
+						});
+					}).catch((ex) => { self.log('readFileContents', ex) });
+				}).catch((ex) => { self.log('getFileId', ex) });
+	
+				function getFileId(parent, name) {
+					var xml = formatXML(`<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><search xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><searchRecord xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:FileSearchAdvanced"><q1:criteria><q1:basic><folder operator="anyOf" xmlns="urn:common_${self.nsVersion}.platform.webservices.netsuite.com"><searchValue internalId="{parent}" type="folder" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></folder><name operator="is" xmlns="urn:common_${self.nsVersion}.platform.webservices.netsuite.com"><searchValue xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{filename}</searchValue></name></q1:basic></q1:criteria><q1:columns><q1:basic><internalId xmlns="urn:common_${self.nsVersion}.platform.webservices.netsuite.com" /></q1:basic></q1:columns></searchRecord></search></soap:Body></soap:Envelope>`,
 						{
 							filename: name,
-							fileid: fileid,
-							parent: parent,
-							content: content
+							parent: parent
 						});
-					return POST(xml, fileid ? 'update' : 'add').then(function () {
-						var verb = fileid ? 'Updated ' : 'Added ';
-						console.log(verb + 'file: ' + name);
-					});
-				});
-			});
-
-			function getFileId(parent, name) {
-				var xml = formatXML('<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><search xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><searchRecord xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:FileSearchAdvanced"><q1:criteria><q1:basic><folder operator="anyOf" xmlns="urn:common_2014_2.platform.webservices.netsuite.com"><searchValue internalId="{parent}" type="folder" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></folder><name operator="is" xmlns="urn:common_2014_2.platform.webservices.netsuite.com"><searchValue xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{filename}</searchValue></name></q1:basic></q1:criteria><q1:columns><q1:basic><internalId xmlns="urn:common_2014_2.platform.webservices.netsuite.com" /></q1:basic></q1:columns></searchRecord></search></soap:Body></soap:Envelope>',
-					{
-						filename: name,
-						parent: parent
-					});
-				return POST(xml, 'search').then(function (data) {
-					if (getTotalRecords(data) > 0) {
-						var matches = data.match(/<platformCore:searchValue internalId="(.*?)"\/>/);
-						if (matches != null) {
-							var id = parseInt(matches[1]);
-							return id;
+					return POST(xml, 'search').then(function (data) {
+						if (getTotalRecords(data) > 0) {
+							var matches = data.match(/<platformCore:searchValue internalId="(.*?)"\/>/);
+							if (matches != null) {
+								var id = parseInt(matches[1]);
+								return id;
+							}
 						}
-					}
-					return undefined;
-				});
+						return undefined;
+					});
+				}
+	
+				function readFileContents(target) {
+					var deferred = Q.defer();
+					fs.readFile(target, function (err, data) {
+						var contents = new Buffer(data).toString('base64');
+						deferred.resolve(contents);
+					});
+					return deferred.promise;
+				}
 			}
-
-			function readFileContents(target) {
-				var deferred = Q.defer();
-				fs.readFile(target, function (err, data) {
-					var contents = new Buffer(data).toString('base64');
-					deferred.resolve(contents);
-				});
-				return deferred.promise;
-			}
-		}
-
-		function getFolderId(parent, foldername) {
-			var key = parent + '|' + foldername.toLowerCase();
-
-			if (folder_cache[key]) {
-				var deferred = Q.defer();
-				deferred.resolve(folder_cache[key]);
-				return deferred.promise;
-			}
-
-			var xml = formatXML('<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><search xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><searchRecord xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:FolderSearch"><q1:basic><name operator="is" xmlns="urn:common_2014_2.platform.webservices.netsuite.com"><searchValue xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{foldername}</searchValue></name><parent operator="anyOf" xmlns="urn:common_2014_2.platform.webservices.netsuite.com"><searchValue internalId="{parent}" type="folder" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></parent></q1:basic></searchRecord></search></soap:Body></soap:Envelope>',
-				{
-					foldername: foldername,
-					parent: parent || '@NONE@'
-				});
-
-			return POST(xml, 'search').then(function (data) {
-				var totalRecords = getTotalRecords(data);
-				if (totalRecords > 0) {
-					var matches = data.match(/internalId="(.*?)"/);
-					if (matches != null) {
-						var id = parseInt(matches[1]);
-						folder_cache[key] = id;
-						return id;
-					} else {
-						throw 'ERR';
-					}
-				} else {
-					var xmlWithParent = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><add xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:Folder"><q1:name>{foldername}</q1:name><q1:parent internalId="{parent}" type="folder" /></record></add></soap:Body></soap:Envelope>';
-					var xmlWithNoParent = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><email xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_2014_2.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_2014_2.platform.webservices.netsuite.com" /></passport></soap:Header><soap:Body><add xmlns="urn:messages_2014_2.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_2014_2.documents.webservices.netsuite.com" xsi:type="q1:Folder"><q1:name>{foldername}</q1:name></record></add></soap:Body></soap:Envelope>';
-
-					var create_xml = formatXML(parent ? xmlWithParent : xmlWithNoParent,
-						{
-							foldername: foldername,
-							parent: parent || '@NONE@'
-						});
-
-					console.log('Creating Folder: ' + foldername + ' Parent: ' + parent);
-					return POST(create_xml, 'add').then(function (data) {
+	
+			function getFolderId(parent, foldername) {
+				var key = parent + '|' + foldername.toLowerCase();
+	
+				if (folder_cache[key]) {
+					var deferred = Q.defer();
+					deferred.resolve(folder_cache[key]);
+					return deferred.promise;
+				}
+	
+				var xml = formatXML(`<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><search xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><searchRecord xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:FolderSearch"><q1:basic><name operator="is" xmlns="urn:common_${self.nsVersion}.platform.webservices.netsuite.com"><searchValue xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{foldername}</searchValue></name><parent operator="anyOf" xmlns="urn:common_${self.nsVersion}.platform.webservices.netsuite.com"><searchValue internalId="{parent}" type="folder" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></parent></q1:basic></searchRecord></search></soap:Body></soap:Envelope>`,
+					{
+						foldername: foldername,
+						parent: parent || '@NONE@'
+					});
+	
+				return POST(xml, 'search').then(function (data) {
+					var totalRecords = getTotalRecords(data);
+					if (totalRecords > 0) {
 						var matches = data.match(/internalId="(.*?)"/);
 						if (matches != null) {
 							var id = parseInt(matches[1]);
@@ -241,26 +245,57 @@ module.exports = (function () {
 						} else {
 							throw 'ERR';
 						}
-					});
+					} else {
+						var xmlWithParent = `<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><add xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:Folder"><q1:name>{foldername}</q1:name><q1:parent internalId="{parent}" type="folder" /></record></add></soap:Body></soap:Envelope>`;
+						var xmlWithNoParent = `<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Header><passport xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><email xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{email}</email><password xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{password}</password><account xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com">{account}</account><role internalId="{role}" xmlns="urn:core_${self.nsVersion}.platform.webservices.netsuite.com" /></passport>${self.globalApplicationIdFragment}</soap:Header><soap:Body><add xmlns="urn:messages_${self.nsVersion}.platform.webservices.netsuite.com"><record xmlns:q1="urn:filecabinet_${self.nsVersion}.documents.webservices.netsuite.com" xsi:type="q1:Folder"><q1:name>{foldername}</q1:name></record></add></soap:Body></soap:Envelope>`;
+	
+						var create_xml = formatXML(parent ? xmlWithParent : xmlWithNoParent,
+							{
+								foldername: foldername,
+								parent: parent || '@NONE@'
+							});
+	
+						self.log('Creating Folder: ' + foldername + ' Parent: ' + parent);
+						return POST(create_xml, 'add').then(function (data) {
+							var matches = data.match(/internalId="(.*?)"/);
+							if (matches != null) {
+								var id = parseInt(matches[1]);
+								folder_cache[key] = id;
+								return id;
+							} else {
+								throw 'ERR';
+							}
+						}).catch((ex) => { self.log('POST-add', ex) });
+					}
+				}).catch((ex) => { self.log('search', ex) });
+			};
+	
+			function getTotalRecords(body) {
+				var matches = body.match(/<platformCore:totalRecords>(.*?)<\/platformCore:totalRecords>/);
+				if (matches != null) {
+					return parseInt(matches[1]);
+				} else {
+					return 0;
 				}
-			});
-		};
-
-		function getTotalRecords(body) {
-			var matches = body.match(/<platformCore:totalRecords>(.*?)<\/platformCore:totalRecords>/);
-			if (matches != null) {
-				return parseInt(matches[1]);
-			} else {
-				return 0;
+			}
+	
+			function validateRequiredFields(params, field_names) {
+				for (var i in field_names) {
+					var field_name = field_names[i];
+					if (!params[field_name])
+						throw field_name + ' is required';
+				}
+			}
+	
+			self.log = function (msg, ex) {
+				if (ex) {
+					console.log('ERROR: ', msg, ex, '\n', ex.stack)
+				}
+				else {
+					console.log(msg)
+				}
 			}
 		}
-
-		function validateRequiredFields(params, field_names) {
-			for (var i in field_names) {
-				var field_name = field_names[i];
-				if (!params[field_name])
-					throw field_name + ' is required';
-			}
-		}
-	}
-})();
+	
+		return SuiteTalk;
+	})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "netsuite-uploader-util",
+  "version": "1.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "readline-sync": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.7.tgz",
+      "integrity": "sha1-ABv91MBhEMPAhMY798alYCIhPzA="
+    },
+    "string-template": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
+      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
+    },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+    },
+    "upath": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-0.1.7.tgz",
+      "integrity": "sha1-fFu/6aTgdP8LgxMa0ME8LYYBODs=",
+      "requires": {
+        "lodash": "3.10.1",
+        "underscore.string": "2.3.3"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    "lodash.endswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+      "integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
+      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.startswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+      "integrity": "sha1-xZjErc4YiiflMUVzHNxsDnF3YAw="
     },
     "q": {
       "version": "1.5.1",
@@ -24,18 +39,15 @@
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
       "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
-    "underscore.string": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
-    },
     "upath": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-0.1.7.tgz",
-      "integrity": "sha1-fFu/6aTgdP8LgxMa0ME8LYYBODs=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.2.tgz",
+      "integrity": "sha512-fCmij7T5LnwUme3dbnVSejvOHHlARjB3ikJFwgZfz386pHmf/gueuTLRFU94FZEaeCLlbQrweiUU700gG41tUw==",
       "requires": {
-        "lodash": "3.10.1",
-        "underscore.string": "2.3.3"
+        "lodash.endswith": "4.2.1",
+        "lodash.isfunction": "3.0.8",
+        "lodash.isstring": "4.0.1",
+        "lodash.startswith": "4.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "q": "^1.4.1",
     "readline-sync": "^1.4.2",
     "string-template": "^1.0.0",
-    "upath": "^0.1.7"
+    "upath": "^1.0.2"
   }
 }


### PR DESCRIPTION


- user is able to  indicate which suitetalk version ant to use
- update default suitetalk version to 2017_2
- better readme 
-  support for applicationid
- updated dependencies
- david-dm badge
- catched errors and log

ged them friendly - before errors are not logged at all!

I tested both things - if you dont pass applpicationid then 2015_1 is used - if you pass applicaiton id and dont pass nsversion the latest know is used (2017_2)

IMPORTANT: david travis is pointing to my user - you need to replace cancerberosgx with your user - is free service - just that. Please accetp this PL !! and I will create another for queue uploads so there is no error with concurrent suitetalk requests ! :P