### PR TITLE
chore: update netsuite latest known version to 2024_2

### DIFF
--- a/lib/suitetalk.js
+++ b/lib/suitetalk.js
@@ -15,7 +15,7 @@ module.exports = (function () {
     function SuiteTalk() {
         let self = this;
 
-        self.nsVersionLatestKnown = '2017_2'
+        self.nsVersionLatestKnown = '2024_2'
 
         // Properties
         self.email = '';


### PR DESCRIPTION
2017_2 suitetalk version has been deprecated and has started throwing errors or stopped working.
Directly updating the installed package with new version had worked for me, so updating here for everyone.